### PR TITLE
修复移除温控模块勾选移除Vendor温控二进制文件导致的卡第一屏

### DIFF
--- a/app/src/main/assets/usr/kr-script/Magisk_Module/Remove_Temperature_Control.sh
+++ b/app/src/main/assets/usr/kr-script/Magisk_Module/Remove_Temperature_Control.sh
@@ -15,6 +15,7 @@ echo "正在移除温控"
 [[ $VendorEX = 1 ]] && {
     for o in `find "/vendor" -name "*thermal*" ! -name "*thermal*.json" ! -name "*thermal*.conf" -type f`; do
         echo "$o" | fgrep -iq 'android.' && continue
+        echo "$o" | fgrep -iq 'lib64' && continue
         echo - $o
         mktouch "$Module/system/$o"
     done


### PR DESCRIPTION
修复移除温控模块勾选移除Vendor温控二进制文件导致的卡第一屏